### PR TITLE
fix: NL Automation Creation end-to-end (v3.0.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog - PilotSuite Core Add-on
 
+## [3.0.1] - 2026-02-19
+
+### Natural Language Automation Creation -- End-to-End Pipeline Fix
+
+- **Neues LLM Tool `pilotsuite.create_automation`**: Der LLM kann jetzt echte
+  HA-Automationen erstellen wenn der User z.B. sagt "Wenn die Kaffeemaschine
+  einschaltet, soll die Kaffeemuehle sich synchronisieren". Der LLM parsed die
+  natuerliche Sprache in strukturierte Trigger/Action-Daten und erstellt die
+  Automation via Supervisor API.
+- **Neues LLM Tool `pilotsuite.list_automations`**: Erstellte Automationen auflisten.
+- **UserHintsService komplett**: `accept_suggestion()` und `reject_suggestion()`
+  implementiert mit AutomationCreator-Bridge. Akzeptierte Suggestions erstellen
+  jetzt echte HA-Automationen.
+- **HintData Model**: `to_dict()` und `to_automation()` Methoden hinzugefuegt.
+- **AutomationCreator erweitert**: Akzeptiert jetzt auch strukturierte
+  Trigger/Action-Dicts (nicht nur Regex-parsbare Strings).
+- **System Prompt aktualisiert**: LLM weiss jetzt ueber seine
+  Automations-Erstellungs-Faehigkeit.
+
+Dateien: `mcp_tools.py`, `api/v1/conversation.py`, `api/v1/service.py`,
+`api/v1/models.py`, `api/v1/user_hints.py`, `automation_creator.py`
+
 ## [3.0.0] - 2026-02-19
 
 ### Kollektive Intelligenz — Cross-Home Learning

--- a/addons/copilot_core/rootfs/usr/src/app/copilot_core/api/v1/models.py
+++ b/addons/copilot_core/rootfs/usr/src/app/copilot_core/api/v1/models.py
@@ -1,8 +1,8 @@
-"""API v1 Models - Stub for User Hints."""
+"""API v1 Models - User Hints data structures."""
 
 from enum import Enum
 from typing import Optional
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 class HintStatus(str, Enum):
@@ -29,6 +29,30 @@ class HintData:
     description: str
     hint_type: HintType
     status: HintStatus
-    entity_ids: list[str]
-    confidence: float
-    metadata: dict
+    entity_ids: list[str] = field(default_factory=list)
+    confidence: float = 0.5
+    metadata: dict = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        """Serialize to a JSON-safe dict."""
+        return {
+            "id": self.hint_id,
+            "title": self.title,
+            "description": self.description,
+            "type": self.hint_type.value if self.hint_type else None,
+            "status": self.status.value if self.status else None,
+            "entity_ids": self.entity_ids,
+            "confidence": self.confidence,
+            "metadata": self.metadata,
+        }
+
+    def to_automation(self) -> dict:
+        """Convert to an automation suggestion dict for the API."""
+        return {
+            "id": self.hint_id,
+            "antecedent": self.title,
+            "consequent": self.description,
+            "confidence": self.confidence,
+            "type": self.hint_type.value if self.hint_type else "suggestion",
+            "entity_ids": self.entity_ids,
+        }

--- a/addons/copilot_core/rootfs/usr/src/app/copilot_core/api/v1/service.py
+++ b/addons/copilot_core/rootfs/usr/src/app/copilot_core/api/v1/service.py
@@ -1,34 +1,136 @@
-"""API v1 Service - Stub for User Hints."""
+"""API v1 Service - User Hints with accept/reject and AutomationCreator bridge."""
 
 from typing import Optional, List, Dict, Any
 from .models import HintData, HintStatus, HintType
 import logging
+import uuid
+import time
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class UserHintsService:
-    """User Hints Service - provides automation suggestions."""
-    
-    def __init__(self):
-        """Initialize the service."""
+    """User Hints Service - provides automation suggestions.
+
+    Bridges the suggestion inbox with the AutomationCreator so that
+    accepting a hint can create a real HA automation.
+    """
+
+    def __init__(self, automation_creator=None):
+        """Initialize the service.
+
+        Parameters
+        ----------
+        automation_creator : AutomationCreator, optional
+            If provided, accepted suggestions are forwarded to the
+            AutomationCreator to create real HA automations.
+        """
         self._hints: Dict[str, HintData] = {}
-    
-    async def get_hints(self) -> List[HintData]:
-        """Get all active hints."""
+        self._automation_creator = automation_creator
+
+    # ------------------------------------------------------------------
+    # Query
+    # ------------------------------------------------------------------
+
+    def get_hints(self, status: Optional[HintStatus] = None) -> List[HintData]:
+        """Get hints, optionally filtered by status."""
+        if status:
+            return [h for h in self._hints.values() if h.status == status]
         return [h for h in self._hints.values() if h.status == HintStatus.ACTIVE]
-    
-    async def add_hint(self, hint: HintData) -> None:
-        """Add a new hint."""
-        self._hints[hint.hint_id] = hint
-    
+
+    async def add_hint(self, text: str, hint_type: Optional[HintType] = None) -> HintData:
+        """Add a new hint from text."""
+        hint_id = uuid.uuid4().hex[:12]
+        hint = HintData(
+            hint_id=hint_id,
+            title=text[:80],
+            description=text,
+            hint_type=hint_type or HintType.SUGGESTION,
+            status=HintStatus.ACTIVE,
+            entity_ids=[],
+            confidence=0.5,
+            metadata={"created_at": time.time()},
+        )
+        self._hints[hint_id] = hint
+        return hint
+
     async def dismiss_hint(self, hint_id: str) -> bool:
         """Dismiss a hint."""
         if hint_id in self._hints:
             self._hints[hint_id].status = HintStatus.DISMISSED
             return True
         return False
-    
+
     async def get_hint_by_id(self, hint_id: str) -> Optional[HintData]:
         """Get a specific hint."""
         return self._hints.get(hint_id)
+
+    def get_suggestions(self) -> List[HintData]:
+        """Get all hints that are suggestions (for automation creation)."""
+        return [
+            h for h in self._hints.values()
+            if h.hint_type in (HintType.AUTOMATION, HintType.SUGGESTION)
+            and h.status == HintStatus.ACTIVE
+        ]
+
+    # ------------------------------------------------------------------
+    # Accept / Reject
+    # ------------------------------------------------------------------
+
+    async def accept_suggestion(self, hint_id: str) -> bool:
+        """Accept a suggestion and attempt to create an HA automation.
+
+        If an AutomationCreator is available, the suggestion is forwarded
+        to it. The hint status is set to DISMISSED regardless.
+        """
+        hint = self._hints.get(hint_id)
+        if not hint:
+            _LOGGER.warning("accept_suggestion: hint %s not found", hint_id)
+            return False
+
+        hint.status = HintStatus.DISMISSED
+        hint.metadata["accepted"] = True
+        hint.metadata["accepted_at"] = time.time()
+
+        # Try to create automation via AutomationCreator
+        if self._automation_creator:
+            try:
+                result = self._automation_creator.create_from_suggestion({
+                    "antecedent": hint.title,
+                    "consequent": hint.description,
+                    "alias": f"PilotSuite: {hint.title[:50]}",
+                })
+                hint.metadata["automation_result"] = result
+                if result.get("ok"):
+                    _LOGGER.info(
+                        "Accepted hint %s -> automation %s",
+                        hint_id, result.get("automation_id"),
+                    )
+                else:
+                    _LOGGER.warning(
+                        "Hint %s accepted but automation creation failed: %s",
+                        hint_id, result.get("error"),
+                    )
+            except Exception as exc:
+                _LOGGER.exception("Error creating automation for hint %s", hint_id)
+                hint.metadata["automation_error"] = str(exc)
+        else:
+            _LOGGER.info("Hint %s accepted (no AutomationCreator available)", hint_id)
+
+        return True
+
+    async def reject_suggestion(self, hint_id: str, reason: Optional[str] = None) -> bool:
+        """Reject a suggestion with optional reason."""
+        hint = self._hints.get(hint_id)
+        if not hint:
+            _LOGGER.warning("reject_suggestion: hint %s not found", hint_id)
+            return False
+
+        hint.status = HintStatus.DISMISSED
+        hint.metadata["rejected"] = True
+        hint.metadata["rejected_at"] = time.time()
+        if reason:
+            hint.metadata["reject_reason"] = reason
+
+        _LOGGER.info("Hint %s rejected (reason: %s)", hint_id, reason or "none")
+        return True

--- a/addons/copilot_core/rootfs/usr/src/app/copilot_core/api/v1/user_hints.py
+++ b/addons/copilot_core/rootfs/usr/src/app/copilot_core/api/v1/user_hints.py
@@ -19,10 +19,18 @@ def init_hints_service(service: UserHintsService) -> None:
 
 
 def get_hints_service() -> UserHintsService:
-    """Get the hints service."""
+    """Get the hints service, auto-wiring AutomationCreator if available."""
     global _hints_service
     if _hints_service is None:
-        _hints_service = UserHintsService()
+        # Try to get AutomationCreator from Flask app context
+        automation_creator = None
+        try:
+            from flask import current_app
+            services = current_app.config.get("COPILOT_SERVICES", {})
+            automation_creator = services.get("automation_creator")
+        except Exception:
+            pass
+        _hints_service = UserHintsService(automation_creator=automation_creator)
     return _hints_service
 
 

--- a/addons/copilot_core/rootfs/usr/src/app/copilot_core/mcp_tools.py
+++ b/addons/copilot_core/rootfs/usr/src/app/copilot_core/mcp_tools.py
@@ -218,6 +218,79 @@ HA_TOOLS = [
             "required": ["entity_id"]
         }
     ),
+
+    # -- PilotSuite Automation Tools -----------------------------------------
+
+    MCPTool(
+        name="pilotsuite.create_automation",
+        description=(
+            "Create a Home Assistant automation. Use this when the user asks to "
+            "set up a rule like 'when X happens, do Y'. You MUST parse the user's "
+            "intent into structured trigger and action data. Supports state, time, "
+            "and sun triggers with turn_on/turn_off/scene/notify actions."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "alias": {
+                    "type": "string",
+                    "description": "Human-readable name for the automation (e.g. 'Coffee grinder sync')"
+                },
+                "trigger_type": {
+                    "type": "string",
+                    "enum": ["state", "time", "sun"],
+                    "description": "Type of trigger: state (entity changes), time (at HH:MM), sun (sunset/sunrise)"
+                },
+                "trigger_entity": {
+                    "type": "string",
+                    "description": "Entity ID that triggers the automation (for state triggers, e.g. switch.coffee_machine)"
+                },
+                "trigger_to": {
+                    "type": "string",
+                    "description": "Target state for state trigger (e.g. 'on', 'off', 'home', 'not_home')"
+                },
+                "trigger_from": {
+                    "type": "string",
+                    "description": "Optional: previous state for state trigger (e.g. 'off' -> 'on')"
+                },
+                "trigger_time": {
+                    "type": "string",
+                    "description": "Time for time trigger in HH:MM:SS format (e.g. '06:30:00')"
+                },
+                "trigger_sun_event": {
+                    "type": "string",
+                    "enum": ["sunset", "sunrise"],
+                    "description": "Sun event for sun trigger"
+                },
+                "trigger_sun_offset": {
+                    "type": "string",
+                    "description": "Optional offset for sun trigger (e.g. '-00:30:00' for 30 min before)"
+                },
+                "action_service": {
+                    "type": "string",
+                    "description": "HA service to call (e.g. 'light.turn_on', 'switch.turn_off', 'scene.turn_on', 'notify.persistent_notification')"
+                },
+                "action_entity": {
+                    "type": "string",
+                    "description": "Entity ID to act on (e.g. 'switch.coffee_grinder', 'light.living_room')"
+                },
+                "action_data": {
+                    "type": "object",
+                    "description": "Optional service data (e.g. {\"brightness_pct\": 50, \"color_temp\": 300})"
+                }
+            },
+            "required": ["alias", "trigger_type", "action_service", "action_entity"]
+        }
+    ),
+
+    MCPTool(
+        name="pilotsuite.list_automations",
+        description="List automations created by PilotSuite/Styx. Use this to show the user what automations have been created.",
+        input_schema={
+            "type": "object",
+            "properties": {}
+        }
+    ),
 ]
 
 

--- a/addons/copilot_core/rootfs/usr/src/app/main.py
+++ b/addons/copilot_core/rootfs/usr/src/app/main.py
@@ -15,7 +15,7 @@ from waitress import serve
 from copilot_core.api.security import require_token, validate_token
 from copilot_core.core_setup import init_services, register_blueprints
 
-APP_VERSION = os.environ.get("COPILOT_VERSION", "3.0.0")
+APP_VERSION = os.environ.get("COPILOT_VERSION", "3.0.1")
 
 
 def _load_options_json(path: str = "/data/options.json") -> dict:


### PR DESCRIPTION
## Summary
- LLM kann jetzt echte HA-Automationen erstellen per natuerlicher Sprache
- 2 neue Tools: `pilotsuite.create_automation`, `pilotsuite.list_automations`
- UserHintsService accept/reject implementiert
- AutomationCreator erweitert fuer strukturierte Daten

## Was funktioniert jetzt
User sagt: "Wenn die Kaffeemaschine einschaltet, schalte die Kaffeemuehle ein"
→ LLM parsed: trigger=state(switch.coffee_machine→on), action=switch.turn_on(switch.coffee_grinder)
→ POST /config/automation/config/styx_xxx → echte HA-Automation erstellt

## Dateien (8 geaendert, +428/-49)
- mcp_tools.py, conversation.py, service.py, models.py, user_hints.py, automation_creator.py, main.py, CHANGELOG.md

https://claude.ai/code/session_01FXoXGQo7v4vZycXu2WCDBN