### PR TITLE
chore: redact private info — JWT, IPs, nabu.casa

### DIFF
--- a/MEMORY.md
+++ b/MEMORY.md
@@ -40,7 +40,7 @@
 ## System Status (Stand 2026-02-15)
 
 ### Dashboard & Orchestrierung
-- **ReactBoard**: http://192.168.30.18:48099/__openclaw__/ReactBoard/ ✅
+- **ReactBoard**: http://<PRIVATE-IP>:48099/__openclaw__/ReactBoard/ ✅
 - **Release Script**: `/config/.openclaw/workspace/scripts/release_system.sh`
 - **Commands**: `status|sync|commit|push|release|dashboard|full`
 
@@ -118,7 +118,7 @@
   - `tags/` = Integration Layer (HabitusZone, API)
 - **Autopilot-Fehler in v0.4.25/v0.4.26** - mood/ und tagging/ fälschlich gelöscht
 - **🚨 2026-02-15 17:24: collective_intelligence/ (+1954 lines) GELÖSCHT!** Wiederhergestellt aus Commit 15fdc45. Pattern wiederholt sich! Working-Directory-Löschungen ohne Commit-Bezug sind gefährlich.
-- **Autopilot-Modell-Auswahl funktioniert**: qwen3-coder-next:cloud für Coding-Tasks via Remote-Ollama (http://192.168.31.84:11434)
+- **Autopilot-Modell-Auswahl funktioniert**: qwen3-coder-next:cloud für Coding-Tasks via Remote-Ollama (http://<OLLAMA-HOST>:11434)
 - **Debug Mode v0.8.0**: Kleiner Scope, sicher, hoher User-Value - gute Autopilot-Aufgabe
 - **Core Add-on API-Blueprint Pattern**: Blueprint in `copilot_core/api/v1/` erstellen und in `blueprint.py` registrieren
 - HA Pipeline Agent ist zur **Beobachtung**, nicht zum Schalten
@@ -265,7 +265,7 @@ State (objektiv) → Neuron (bewertet Aspekt) → Mood (aggregiert Bedeutung) �
 
 ## Ollama Models (Stand 2026-02-14 21:30)
 ### Server:
-- **Remote**: `http://192.168.31.84:11434` ✅ PRIMARY
+- **Remote**: `http://<OLLAMA-HOST>:11434` ✅ PRIMARY
 - **Lokal**: `http://localhost:11434` (Fallback)
 
 ### Hauptmodelle (Ollama Cloud):
@@ -295,23 +295,23 @@ qwen3-coder-next:cloud (Coding/Reasoning) → glm-5:cloud (Primary) → minimax-
 ### Spezial:
 - **Bilder**: kimi-k2.5:cloud (Vision-Modell)
 - **TTS**: OpenAI (bereits konfiguriert)
-- **Neue Modelle**: Per API pullen: `curl -X POST http://192.168.31.84:11434/api/pull -d '{"name": "modell:tag"}'`
+- **Neue Modelle**: Per API pullen: `curl -X POST http://<OLLAMA-HOST>:11434/api/pull -d '{"name": "modell:tag"}'`
 
 ### Konfiguration:
 - **CLI**: `./bin/openclaw-cli status|test|models`
 - **Config**: `config/models.sh`
-- **Env**: `OLLAMA_HOST=http://192.168.31.84:11434`
+- **Env**: `OLLAMA_HOST=http://<OLLAMA-HOST>:11434`
 
 ### Usage:
 ```bash
 # Status
-export OLLAMA_HOST="http://192.168.31.84:11434" && ./bin/openclaw-cli status
+export OLLAMA_HOST="http://<OLLAMA-HOST>:11434" && ./bin/openclaw-cli status
 
 # Test
 ./bin/openclaw-cli test
 
 # API call direkt
-curl -s "http://192.168.31.84:11434/api/generate" \
+curl -s "http://<OLLAMA-HOST>:11434/api/generate" \
   -d '{"model": "glm-5:cloud", "prompt": "Hi", "stream": false}'
 ```
 # Status check
@@ -330,11 +330,11 @@ curl http://localhost:11434/api/generate \
 ## Home Assistant Integration (2026-02-17)
 
 ### HA API Zugriff
-**Nabu Casa URL:** `https://js71lc792ufv9o245ysczlg2wj1mmgfu.ui.nabu.casa`
+**Nabu Casa URL:** `https://<REDACTED>.ui.nabu.casa`
 
 **Longlife Token:** (aus .openclaw/openclaw.json HOMEASSISTANT_TOKEN)
 ```
-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhMjBjYmI1MWE3OTY0ODBmYmZlOGI0YzMxYTNjZTQ4MCIsImlhdCI6MTc3MDM5NzI0NCwiZXhwIjoyMDg1NzU3MjQ0fQ.GPoq80EzJU1pUhjiPTF2_1RYtpAn0rwifEro04JC6h8
+<REDACTED - HA Long-Lived Access Token>
 ```
 
 **Verfügbare Lichter:**

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -23,7 +23,7 @@ Things like:
 
 ### SSH
 
-- home-server → 192.168.1.100, user: admin
+- home-server → <PRIVATE-IP>, user: admin
 
 ### TTS
 

--- a/docs/archive/PHASE5_IMPLEMENTATION.md
+++ b/docs/archive/PHASE5_IMPLEMENTATION.md
@@ -167,7 +167,7 @@ await discovery.start()
 await discovery.publish()
 
 # Connect to other homes
-await sync.connect("home-2", host="192.168.1.100")
+await sync.connect("home-2", host="<PRIVATE-IP>")
 
 # Register entities
 registry.register("light.living_room", shared=True, home_id="home-1")

--- a/docs/archive/TOOLS.md
+++ b/docs/archive/TOOLS.md
@@ -23,7 +23,7 @@ Things like:
 
 ### SSH
 
-- home-server → 192.168.1.100, user: admin
+- home-server → <PRIVATE-IP>, user: admin
 
 ### TTS
 

--- a/docs/archive/memory/2026-02-13.md
+++ b/docs/archive/memory/2026-02-13.md
@@ -3,8 +3,8 @@
 ## Ollama - EXTERNER SERVER ✅
 
 ### Konfiguration
-- **Host:** `192.168.31.84:11434` (externer Ollama Server)
-- **OLLAMA_HOST:** `192.168.31.84:11434`
+- **Host:** `<OLLAMA-HOST>:11434` (externer Ollama Server)
+- **OLLAMA_HOST:** `<OLLAMA-HOST>:11434`
 - **Start-Skript:** `/config/.ollama/start-ollama.sh`
 
 ### Verfügbare Modelle (extern)
@@ -37,7 +37,7 @@
 | Codex CLI | ✅ Works | gpt-5.2-codex, OpenAI API key |
 | Gemini CLI | ✅ Works | OAuth, v0.28.2 |
 | Claude CLI | ⚠️ Local only | OAuth works, exec hangs |
-| Ollama | ✅ Extern | 192.168.31.84:11434 |
+| Ollama | ✅ Extern | <OLLAMA-HOST>:11434 |
 
 ## Skills Created
 

--- a/docs/archive/notes/AI_HOME_COPILOT_DEEP_RESEARCH_REPORT.md
+++ b/docs/archive/notes/AI_HOME_COPILOT_DEEP_RESEARCH_REPORT.md
@@ -145,7 +145,7 @@ ai_home_copilot:
 
 ### 3.1 ReactBoard 404 Analyse
 
-**Problem:** ReactBoard unter `http://192.168.30.18:48099/__openclaw__/ReactBoard/` gibt 404 zurück.
+**Problem:** ReactBoard unter `http://<PRIVATE-IP>:48099/__openclaw__/ReactBoard/` gibt 404 zurück.
 
 **Ursachen:**
 1. **Nicht im Core Add-on implementiert** - ReactBoard ist ein externes OpenClaw-Feature
@@ -254,7 +254,7 @@ openclaw gateway status
 openclaw gateway start
 
 # 3. Prüfe ReactBoard URL
-# http://192.168.30.18:48099/__openclaw__/ReactBoard/
+# http://<PRIVATE-IP>:48099/__openclaw__/ReactBoard/
 ```
 
 ---

--- a/homeassistant_skill_setup.md
+++ b/homeassistant_skill_setup.md
@@ -34,8 +34,8 @@ Jeder Agent kann nun HA steuern:
 
 ```bash
 # Beispiel: Deckenlicht ausschalten
-curl -X POST "https://js71lc792ufv9o245ysczlg2wj1mmgfu.ui.nabu.casa/api/services/light/turn_off" \
-  -H "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..." \
+curl -X POST "https://<YOUR-INSTANCE>.ui.nabu.casa/api/services/light/turn_off" \
+  -H "Authorization: Bearer <YOUR-HA-TOKEN>" \
   -d '{"entity_id": "light.deckenlicht"}'
 ```
 

--- a/scripts/ollama-websearch
+++ b/scripts/ollama-websearch
@@ -15,7 +15,7 @@ import urllib.request
 import urllib.error
 import time
 
-OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://192.168.31.84:11434")
+OLLAMA_HOST = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
 OLLAMA_API_KEY = os.environ.get("OLLAMA_API_KEY", "")
 
 # kimi-k2.5 has tools + thinking + vision + native web search
@@ -164,7 +164,7 @@ def main():
         print("Usage: ollama-websearch \"your query\"", file=sys.stderr)
         print("", file=sys.stderr)
         print("Environment variables:", file=sys.stderr)
-        print("  OLLAMA_HOST        Ollama server (default: http://192.168.31.84:11434)", file=sys.stderr)
+        print("  OLLAMA_HOST        Ollama server (default: http://localhost:11434)", file=sys.stderr)
         print("  OLLAMA_API_KEY     API key for cloud models", file=sys.stderr)
         print("  OLLAMA_WEB_MODEL   Model to use (default: kimi-k2.5:cloud)", file=sys.stderr)
         print("  PERPLEXITY_API_KEY For actual web search", file=sys.stderr)

--- a/scripts/sync_workspace.sh
+++ b/scripts/sync_workspace.sh
@@ -51,7 +51,7 @@ sync_repo "$REPO_CORE" "Core Add-on"
 
 # Check React Board
 echo "--- React Board ---"
-if curl -s -o /dev/null -w "%{http_code}" "http://192.168.30.18:48099/__openclaw__/ReactBoard/" | grep -q "200"; then
+if curl -s -o /dev/null -w "%{http_code}" "http://${REACTBOARD_HOST:-localhost}:48099/__openclaw__/ReactBoard/" | grep -q "200"; then
     echo "✅ React Board UP"
 else
     echo "⚠️ React Board not responding"


### PR DESCRIPTION
## Summary
- Redact hardcoded HA JWT token from MEMORY.md (CRITICAL)
- Redact nabu.casa instance URL from MEMORY.md + homeassistant_skill_setup.md
- Replace all hardcoded private IPs (192.168.x.x) with placeholders/env vars
- Scripts: use localhost/env var defaults instead of hardcoded IPs

## Test plan
- [ ] grep for 192.168 returns only test fixtures (test_unifi.py)
- [ ] grep for nabu.casa returns only redacted placeholders
- [ ] grep for eyJhbG returns zero results

https://claude.ai/code/session_01FXoXGQo7v4vZycXu2WCDBN