### PR TITLE
fix(v3.2.3): haushalt alerts + entity_assignment + LLM tag context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog - PilotSuite Core Add-on
 
+## [3.2.3] - 2026-02-19
+
+### Bugfixes
+
+- **Fix: Haushalt Alert-Duplikation** — Müll- und Geburtstags-Alerts wurden im Dashboard
+  gegenseitig gespiegelt (beide Karten zeigten alle Alerts). Jetzt typ-getrennt
+- **Fix: entity_assignment None-Unterscheidung** — `_fetch_states()` gibt `None` bei API-Fehler
+  zurück vs. `[]` wenn API ok aber keine Entitäten → korrekter Fehlertext im UI
+- **Fix: haushalt.py birthday KeyError** — `b['age']` → `b.get('age', '?')` in Geburtstags-Reminder
+- **Feature: Entity-Tags LLM-Kontext** — `tag_registry.get_context_for_llm()` wird in LLM
+  System-Prompt injiziert, sodass Styx Tag-Zuweisungen kennt
+- Version: 3.2.2 → 3.2.3
+
 ## [3.2.2] - 2026-02-19
 
 ### Hauswirtschafts-Dashboard + Entity Suggestions API

--- a/addons/copilot_core/config.json
+++ b/addons/copilot_core/config.json
@@ -2,7 +2,7 @@
   "name": "PilotSuite Core",
   "slug": "copilot_core",
   "description": "MVP Core Service for PilotSuite with Multi-User Preference Learning, Knowledge Graph, Brain Graph visualization, Cross-Home Sync, and Collective Intelligence.",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "url": "https://github.com/GreenhillEfka/Home-Assistant-Copilot",
   "arch": [
     "amd64",

--- a/addons/copilot_core/rootfs/usr/src/app/copilot_core/api/v1/conversation.py
+++ b/addons/copilot_core/rootfs/usr/src/app/copilot_core/api/v1/conversation.py
@@ -441,6 +441,16 @@ def _get_user_context() -> str:
             except Exception:
                 pass
 
+        # Entity tags context (v3.2.3)
+        tag_registry = services.get("tag_registry")
+        if tag_registry and hasattr(tag_registry, "get_context_for_llm"):
+            try:
+                tags_ctx = tag_registry.get_context_for_llm()
+                if tags_ctx:
+                    context_parts.append(tags_ctx)
+            except Exception:
+                pass
+
     except Exception as exc:
         logger.debug("Could not load user context: %s", exc)
 

--- a/addons/copilot_core/rootfs/usr/src/app/copilot_core/api/v1/entity_assignment.py
+++ b/addons/copilot_core/rootfs/usr/src/app/copilot_core/api/v1/entity_assignment.py
@@ -83,10 +83,11 @@ def _fetch_states() -> list[dict]:
             timeout=10,
         )
         if resp.ok:
-            return resp.json() or []
+            data = resp.json()
+            return data if isinstance(data, list) else []
     except Exception as exc:
         _LOGGER.warning("Failed to fetch HA states: %s", exc)
-    return []
+    return None
 
 
 @entity_assignment_bp.route("/suggestions", methods=["GET"])
@@ -94,8 +95,10 @@ def _fetch_states() -> list[dict]:
 def get_suggestions():
     """Return entity groupings with zone assignment suggestions."""
     states = _fetch_states()
+    if states is None:
+        return jsonify({"ok": False, "error": "Supervisor API nicht erreichbar", "suggestions": []})
     if not states:
-        return jsonify({"ok": False, "error": "Could not fetch HA states", "suggestions": []})
+        return jsonify({"ok": True, "suggestion_count": 0, "suggestions": []})
 
     # Group entities by room hint
     groups: dict[str, list[dict]] = defaultdict(list)

--- a/addons/copilot_core/rootfs/usr/src/app/copilot_core/api/v1/haushalt.py
+++ b/addons/copilot_core/rootfs/usr/src/app/copilot_core/api/v1/haushalt.py
@@ -95,7 +95,7 @@ def haushalt_remind_birthday():
         today = status.get("today", [])
         if not today:
             return jsonify({"ok": True, "message": "Keine Geburtstage heute."})
-        names = [b.get("name", "?") + (f" (wird {b['age']})" if b.get("age") else "") for b in today]
+        names = [b.get("name", "?") + (f" (wird {b.get('age', '?')})" if b.get("age") else "") for b in today]
         message = f"Heute hat Geburtstag: {', '.join(names)}. Herzlichen Glückwunsch!"
         return jsonify(birthday_service.deliver_reminder(message))
     except Exception as exc:

--- a/addons/copilot_core/rootfs/usr/src/app/templates/dashboard.html
+++ b/addons/copilot_core/rootfs/usr/src/app/templates/dashboard.html
@@ -1106,15 +1106,16 @@ async function loadHaushaltData(){
       $('haushalt-birthdays').innerHTML='<div class="empty">Haushalt API nicht verfügbar</div>';
       return;
     }
-    // -- Alerts strip --
+    // -- Alerts strip (separated by type) --
     const alerts=r.alerts||{};
-    let alertHtml='';
-    if(alerts.birthday_today){alertHtml+=badge('&#x1f382; Geburtstag heute!','g')+' '}
-    if(alerts.waste_today){alertHtml+=badge('&#x267b; Abfuhr heute!','r')+' '}
-    if(alerts.waste_tomorrow){alertHtml+=badge('&#x267b; Abfuhr morgen','y')+' '}
-    if(alerts.upcoming_birthdays_7d>0){alertHtml+=badge('&#x1f382; '+alerts.upcoming_birthdays_7d+' Geburtstage diese Woche','b')+' '}
-    $('haushalt-waste-alerts').innerHTML=alertHtml;
-    $('haushalt-birthday-alerts').innerHTML=alertHtml;
+    let wasteAlertHtml='';
+    if(alerts.waste_today){wasteAlertHtml+=badge('&#x267b; Abfuhr heute!','r')+' '}
+    if(alerts.waste_tomorrow){wasteAlertHtml+=badge('&#x267b; Abfuhr morgen','y')+' '}
+    let bdayAlertHtml='';
+    if(alerts.birthday_today){bdayAlertHtml+=badge('&#x1f382; Geburtstag heute!','g')+' '}
+    if(alerts.upcoming_birthdays_7d>0){bdayAlertHtml+=badge('&#x1f382; '+alerts.upcoming_birthdays_7d+' diese Woche','b')+' '}
+    $('haushalt-waste-alerts').innerHTML=wasteAlertHtml;
+    $('haushalt-birthday-alerts').innerHTML=bdayAlertHtml;
 
     // -- Waste --
     const waste=r.waste||{};


### PR DESCRIPTION
## Summary
- Haushalt dashboard: waste and birthday alert badges were identical in both cards
- entity_assignment: proper None vs [] distinction, better error messages
- haushalt.py: birthday age KeyError fix
- conversation.py: entity tag context injected into LLM system prompt

## Test plan
- [ ] Haushalt tab: waste alerts only in waste card, birthday alerts only in birthday card
- [ ] /api/v1/entity-assignment/suggestions: returns proper error when Supervisor down

https://claude.ai/code/session_01FXoXGQo7v4vZycXu2WCDBN