### PR TITLE
fix: v3.8.1 — mood service os.makedirs fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog - PilotSuite Core Add-on
 
+## [3.8.1] - 2026-02-19
+
+### Startup Reliability Patch
+
+- **`mood/service.py` — `os.makedirs()` fix** — `_init_db()` now calls
+  `os.makedirs(os.path.dirname(db_path), exist_ok=True)` before `sqlite3.connect()`.
+  Prevents `FileNotFoundError` when `/data/` directory does not yet exist on first start.
+
 ## [3.8.0] - 2026-02-19
 
 ### Persistent State — Mood, Alerts & Mining Buffer

--- a/addons/copilot_core/config.json
+++ b/addons/copilot_core/config.json
@@ -2,7 +2,7 @@
   "name": "PilotSuite Core",
   "slug": "copilot_core",
   "description": "MVP Core Service for PilotSuite with Multi-User Preference Learning, Knowledge Graph, Brain Graph visualization, Cross-Home Sync, and Collective Intelligence.",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "url": "https://github.com/GreenhillEfka/Home-Assistant-Copilot",
   "arch": [
     "amd64",

--- a/addons/copilot_core/rootfs/usr/src/app/copilot_core/mood/service.py
+++ b/addons/copilot_core/rootfs/usr/src/app/copilot_core/mood/service.py
@@ -83,6 +83,7 @@ class MoodService:
 
     def _init_db(self):
         """Create mood_snapshots table if it doesn't exist."""
+        os.makedirs(os.path.dirname(self._db_path) or ".", exist_ok=True)
         with self._lock:
             conn = sqlite3.connect(self._db_path)
             try:

--- a/addons/copilot_core/rootfs/usr/src/app/main.py
+++ b/addons/copilot_core/rootfs/usr/src/app/main.py
@@ -19,7 +19,7 @@ from waitress import serve
 from copilot_core.api.security import require_token, validate_token
 from copilot_core.core_setup import init_services, register_blueprints
 
-APP_VERSION = os.environ.get("COPILOT_VERSION", "3.8.0")
+APP_VERSION = os.environ.get("COPILOT_VERSION", "3.8.1")
 
 _main_logger = _logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

- **`mood/service.py`** — `_init_db()` now calls `os.makedirs(os.path.dirname(db_path), exist_ok=True)` before `sqlite3.connect()`. Prevents `FileNotFoundError` when `/data/` directory does not yet exist on first addon start.
- **Version**: 3.8.0 → 3.8.1

## Test plan
- [ ] Fresh addon start on new HA instance — `/data/mood_history.db` created without error
- [ ] Mood service initializes correctly on startup
- [ ] Mood history persists across restarts

https://claude.ai/code/session_01FXoXGQo7v4vZycXu2WCDBN