### PR TITLE
fix: v3.9.0 — Mood prune logic fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog - PilotSuite Core Add-on
 
+## [3.9.0] - 2026-02-19
+
+### Production-Ready Bug Sweep
+
+- **`mood/service.py` — prune logic fix** — The periodic DB cleanup used
+  `len(self._last_save_ts) % 100` (number of zones) instead of a global save counter.
+  Since zone count rarely changes, `_prune_old()` effectively never ran, causing
+  unbounded DB growth. Replaced with `_save_count` counter that increments on every save.
+
 ## [3.8.1] - 2026-02-19
 
 ### Startup Reliability Patch

--- a/addons/copilot_core/config.json
+++ b/addons/copilot_core/config.json
@@ -2,7 +2,7 @@
   "name": "PilotSuite Core",
   "slug": "copilot_core",
   "description": "MVP Core Service for PilotSuite with Multi-User Preference Learning, Knowledge Graph, Brain Graph visualization, Cross-Home Sync, and Collective Intelligence.",
-  "version": "3.8.1",
+  "version": "3.9.0",
   "url": "https://github.com/GreenhillEfka/Home-Assistant-Copilot",
   "arch": [
     "amd64",

--- a/addons/copilot_core/rootfs/usr/src/app/main.py
+++ b/addons/copilot_core/rootfs/usr/src/app/main.py
@@ -19,7 +19,7 @@ from waitress import serve
 from copilot_core.api.security import require_token, validate_token
 from copilot_core.core_setup import init_services, register_blueprints
 
-APP_VERSION = os.environ.get("COPILOT_VERSION", "3.8.1")
+APP_VERSION = os.environ.get("COPILOT_VERSION", "3.9.0")
 
 _main_logger = _logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

- **`mood/service.py` — prune logic fix** — DB cleanup used `len(self._last_save_ts) % 100` (number of zones, barely changes) so `_prune_old()` effectively never ran. Replaced with `_save_count` counter incrementing on every persist → cleanup now runs every 100th save as intended.
- **Version**: 3.8.1 → 3.9.0

## Test plan
- [ ] Mood service starts correctly
- [ ] After 100+ mood saves, `_prune_old()` is called (verify via debug logs)
- [ ] DB does not grow unbounded over 30 days

https://claude.ai/code/session_01FXoXGQo7v4vZycXu2WCDBN