### PR TITLE
feat: v4.2.0 — Scheduled Brain Graph Pruning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog - PilotSuite Core Add-on
 
+## [4.2.0] - 2026-02-20
+
+### Brain Graph Scheduled Pruning
+
+- **brain_graph/service.py** — Daemon-Thread für zeitbasiertes Pruning; konfigurierbar via `prune_interval_minutes` (Standard: 60 Min); automatischer Start beim Service-Init; Prune-Statistiken in `get_stats()` sichtbar
+- **core_setup.py** — `prune_interval_minutes` aus Brain-Graph-Config gelesen; `start_scheduled_pruning()` beim Init aufgerufen
+- **config.json** — Version auf 4.2.0
+
 ## [4.1.0] - 2026-02-20
 
 ### Race Conditions + Stability

--- a/copilot_core/config.json
+++ b/copilot_core/config.json
@@ -2,7 +2,7 @@
   "name": "PilotSuite Core",
   "slug": "copilot_core",
   "description": "MVP Core Service for PilotSuite with Multi-User Preference Learning, Knowledge Graph, Brain Graph visualization, Cross-Home Sync, and Collective Intelligence.",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "url": "https://github.com/GreenhillEfka/pilotsuite-styx-core",
   "arch": [
     "amd64",

--- a/copilot_core/rootfs/usr/src/app/copilot_core/core_setup.py
+++ b/copilot_core/rootfs/usr/src/app/copilot_core/core_setup.py
@@ -131,7 +131,9 @@ def init_services(hass=None, config: dict = None):
             ),
             node_half_life_hours=_safe_float(bg_config.get("node_half_life_hours", 24.0), 24.0, 0.1, 8760.0),
             edge_half_life_hours=_safe_float(bg_config.get("edge_half_life_hours", 12.0), 12.0, 0.1, 8760.0),
+            prune_interval_minutes=_safe_int(bg_config.get("prune_interval_minutes", 60), 60, 1, 1440),
         )
+        brain_graph_service.start_scheduled_pruning()
         services["brain_graph_service"] = brain_graph_service
         services["graph_renderer"] = GraphRenderer()
         init_brain_graph_api(brain_graph_service, services["graph_renderer"])


### PR DESCRIPTION
## Summary
- Background daemon thread for periodic graph pruning (default: every 60 minutes)
- Configurable via `brain_graph.prune_interval_minutes` in options
- Prune statistics visible in `GET /api/v1/graph/stats` → `last_prune`
- Auto-started on service initialization

## Test plan
- [ ] Verify addon starts with scheduled pruning active in logs
- [ ] Verify `GET /api/v1/graph/stats` shows `config.prune_interval_minutes`
- [ ] Verify after waiting 1 interval, `last_prune` appears in stats

https://claude.ai/code/session_01JsNTv2Rn83psriC7Fap15Y