### PR TITLE
fix: OpenAPI spec version + server URLs

### DIFF
--- a/copilot_core/rootfs/usr/src/app/docs/openapi.yaml
+++ b/copilot_core/rootfs/usr/src/app/docs/openapi.yaml
@@ -18,7 +18,7 @@ info:
     
     ## Idempotency
     Event endpoints support `Idempotency-Key` header for deduplication.
-  version: 0.9.1-alpha.6
+  version: 4.2.0
   contact:
     name: PilotSuite
     url: https://github.com/GreenhillEfka/pilotsuite-styx-core
@@ -27,9 +27,9 @@ info:
     url: https://opensource.org/licenses/MIT
 
 servers:
-  - url: http://homeassistant.local:8123/api/copilot
-    description: Home Assistant Core Add-on
-  - url: http://localhost:48099
+  - url: http://homeassistant.local:8909
+    description: PilotSuite Core Add-on (default port)
+  - url: http://localhost:8909
     description: Development server
 
 tags:


### PR DESCRIPTION
## Summary
- Update OpenAPI spec version from 0.9.1-alpha.6 to 4.2.0
- Fix server URLs: port 48099 → 8909, path /api/copilot removed

https://claude.ai/code/session_01JsNTv2Rn83psriC7Fap15Y