### PR TITLE
feat: v4.3.0 — MUPL Role API + Delegation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog - PilotSuite Core Add-on
 
+## [4.3.0] - 2026-02-20
+
+### MUPL Role Sync + Delegation API
+
+- **api/v1/user_preferences.py** — Neue Endpoints: `GET /user/<id>/role` (Rolle abfragen), `GET /user/roles` (alle Rollen), `POST /user/<id>/device/<id>` (Device-Nutzung registrieren), `GET /user/<id>/access/<id>` (RBAC-Prüfung), `POST /user/<id>/delegate` (Gerätezugriff delegieren), `DELETE /user/<id>/delegate` (Delegation widerrufen), `GET /user/delegations` (aktive Delegationen auflisten)
+- **neurons/mupl.py** — Fehlenden `Any`-Typ-Import hinzugefügt
+- **storage/user_preferences.py** — Generische `_load_extra`/`_save_extra` Methoden für Delegation-Persistenz (JSON-basiert)
+- **config.json** — Version auf 4.3.0
+
 ## [4.2.0] - 2026-02-20
 
 ### Brain Graph Scheduled Pruning

--- a/copilot_core/config.json
+++ b/copilot_core/config.json
@@ -2,7 +2,7 @@
   "name": "PilotSuite Core",
   "slug": "copilot_core",
   "description": "MVP Core Service for PilotSuite with Multi-User Preference Learning, Knowledge Graph, Brain Graph visualization, Cross-Home Sync, and Collective Intelligence.",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "url": "https://github.com/GreenhillEfka/pilotsuite-styx-core",
   "arch": [
     "amd64",

--- a/copilot_core/rootfs/usr/src/app/copilot_core/neurons/mupl.py
+++ b/copilot_core/rootfs/usr/src/app/copilot_core/neurons/mupl.py
@@ -23,7 +23,7 @@ import logging
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Dict, List, Optional, Set
+from typing import Any, Dict, List, Optional, Set
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/copilot_core/rootfs/usr/src/app/copilot_core/storage/user_preferences.py
+++ b/copilot_core/rootfs/usr/src/app/copilot_core/storage/user_preferences.py
@@ -383,12 +383,32 @@ class UserPreferenceStore:
             "exported_at": _now_iso(),
         }
     
+    # ==================== Generic Extra Storage ====================
+
+    def _load_extra(self, key: str) -> Any:
+        """Load a named JSON blob from /data/{key}.json."""
+        path = os.path.join(self.data_dir, f"{key}.json")
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                return json.load(fh)
+        except (FileNotFoundError, json.JSONDecodeError):
+            return None
+
+    def _save_extra(self, key: str, data: Any) -> None:
+        """Save a named JSON blob to /data/{key}.json."""
+        if not self.persist:
+            return
+        os.makedirs(self.data_dir, exist_ok=True)
+        path = os.path.join(self.data_dir, f"{key}.json")
+        with open(path, "w", encoding="utf-8") as fh:
+            json.dump(data, fh, ensure_ascii=False, indent=2)
+
     def clear_all(self) -> None:
         """Clear all stored data (for testing/reset)."""
         self._users.clear()
         self._affinities.clear()
         self._active_users.clear()
-        
+
         if self.persist:
             for path in [self.users_path, self.affinities_path]:
                 try:


### PR DESCRIPTION
## Summary
- MUPL Role inference API: GET /user/<id>/role, GET /user/roles
- RBAC access check: GET /user/<id>/access/<device_id>
- Delegation: POST /user/<id>/delegate, DELETE /user/<id>/delegate, GET /user/delegations
- Device usage tracking: POST /user/<id>/device/<device_id>
- Generic _load_extra/_save_extra storage for delegation persistence

## Test plan
- [ ] Verify role inference returns correct roles based on device count
- [ ] Verify delegation creates and persists correctly
- [ ] Verify delegation expiry works
- [ ] Verify RBAC access check respects roles

https://claude.ai/code/session_01JsNTv2Rn83psriC7Fap15Y