### PR TITLE
v5.6.0: Dashboard Config API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog - PilotSuite Core Add-on
 
+## [5.6.0] - 2026-02-21
+
+### Dashboard Config API — Lovelace Card Generation Support
+
+#### API Endpoint (NEW)
+- `GET /api/v1/energy/dashboard-config` — Returns zone list, endpoint URLs, and current energy state for HA card generation
+
+#### Infrastructure
+- **config.json** — Version 5.6.0
+
 ## [5.5.0] - 2026-02-21
 
 ### Smart Schedule Planner — Optimal 24h Device Scheduling

--- a/copilot_core/config.json
+++ b/copilot_core/config.json
@@ -2,7 +2,7 @@
   "name": "PilotSuite Core",
   "slug": "copilot_core",
   "description": "MVP Core Service for PilotSuite with Multi-User Preference Learning, Knowledge Graph, Brain Graph visualization, Cross-Home Sync, and Collective Intelligence.",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "url": "https://github.com/GreenhillEfka/pilotsuite-styx-core",
   "arch": [
     "amd64",


### PR DESCRIPTION
## Summary
- New `GET /api/v1/energy/dashboard-config` endpoint
- Returns zones, endpoint URLs, current energy state for HA card generator

## Test plan
- [ ] Verify endpoint returns zones and state data

https://claude.ai/code/session_01JsNTv2Rn83psriC7Fap15Y