### PR TITLE
v5.9.0: Automation Suggestion Engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog - PilotSuite Core Add-on
 
+## [5.9.0] - 2026-02-21
+
+### Automation Suggestions — Generate HA Automations from Patterns
+
+#### Automation Suggestion Engine (NEW)
+- **automations/suggestion_engine.py** — Generates HA automation YAML from observed patterns
+- 4 suggestion types:
+  - **Time-based**: Schedule device runs at optimal hours (weekday/daily)
+  - **Solar-based**: Start devices when PV surplus exceeds threshold
+  - **Comfort-based**: Trigger actions on CO2, temperature, humidity thresholds
+  - **Presence-based**: Away-mode actions when nobody home
+- Accept/dismiss workflow for user-driven curation
+- Confidence scoring and savings estimates per suggestion
+- Valid HA automation YAML output ready for direct import
+
+#### API Endpoints (NEW)
+- `GET /api/v1/automations/suggestions` — List suggestions with category filter
+- `POST /api/v1/automations/suggestions/{id}/accept` — Accept a suggestion
+- `POST /api/v1/automations/suggestions/{id}/dismiss` — Dismiss a suggestion
+- `GET /api/v1/automations/suggestions/{id}/yaml` — Raw YAML for a suggestion
+- `POST /api/v1/automations/generate` — Bulk-generate from schedule/solar/comfort/presence data
+
+#### Test Suite (NEW — 30+ tests)
+- **tests/test_automation_suggestions.py** — Schedule, solar, comfort, presence, management
+
+#### Infrastructure
+- **automations/__init__.py** — Module with public exports
+- **config.json** — Version 5.9.0
+
 ## [5.8.0] - 2026-02-21
 
 ### Notification Engine — Smart Alert Aggregation

--- a/copilot_core/config.json
+++ b/copilot_core/config.json
@@ -2,7 +2,7 @@
   "name": "PilotSuite Core",
   "slug": "copilot_core",
   "description": "MVP Core Service for PilotSuite with Multi-User Preference Learning, Knowledge Graph, Brain Graph visualization, Cross-Home Sync, and Collective Intelligence.",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "url": "https://github.com/GreenhillEfka/pilotsuite-styx-core",
   "arch": [
     "amd64",

--- a/copilot_core/rootfs/usr/src/app/copilot_core/automations/__init__.py
+++ b/copilot_core/rootfs/usr/src/app/copilot_core/automations/__init__.py
@@ -1,0 +1,3 @@
+"""Automations module for PilotSuite (v5.9.0)."""
+
+from .suggestion_engine import AutomationSuggestionEngine  # noqa: F401

--- a/copilot_core/rootfs/usr/src/app/copilot_core/automations/api.py
+++ b/copilot_core/rootfs/usr/src/app/copilot_core/automations/api.py
@@ -1,0 +1,130 @@
+"""Automation Suggestions API (v5.9.0)."""
+
+import yaml
+from flask import Blueprint, Response, jsonify, request
+
+from ..api.security import require_api_key
+from .suggestion_engine import AutomationSuggestionEngine
+
+automations_bp = Blueprint("automations", __name__)
+
+_engine: AutomationSuggestionEngine | None = None
+
+
+def init_automations_api(engine: AutomationSuggestionEngine) -> None:
+    global _engine
+    _engine = engine
+
+
+@automations_bp.route("/api/v1/automations/suggestions", methods=["GET"])
+@require_api_key
+def get_suggestions():
+    """Get automation suggestions.
+
+    Query params:
+        category: time, energy, comfort, presence
+        include_dismissed: true/false
+    """
+    if not _engine:
+        return jsonify({"error": "Automation engine not initialized"}), 503
+
+    category = request.args.get("category")
+    dismissed = request.args.get("include_dismissed", "false").lower() == "true"
+
+    items = _engine.get_suggestions(category=category, include_dismissed=dismissed)
+    return jsonify({"ok": True, "count": len(items), "suggestions": items})
+
+
+@automations_bp.route("/api/v1/automations/suggestions/<suggestion_id>/accept", methods=["POST"])
+@require_api_key
+def accept_suggestion(suggestion_id: str):
+    """Accept a suggestion."""
+    if not _engine:
+        return jsonify({"error": "Automation engine not initialized"}), 503
+
+    result = _engine.accept_suggestion(suggestion_id)
+    if result:
+        return jsonify({"ok": True, **result})
+    return jsonify({"ok": False, "error": "Suggestion not found"}), 404
+
+
+@automations_bp.route("/api/v1/automations/suggestions/<suggestion_id>/dismiss", methods=["POST"])
+@require_api_key
+def dismiss_suggestion(suggestion_id: str):
+    """Dismiss a suggestion."""
+    if not _engine:
+        return jsonify({"error": "Automation engine not initialized"}), 503
+
+    result = _engine.dismiss_suggestion(suggestion_id)
+    if result:
+        return jsonify({"ok": True, **result})
+    return jsonify({"ok": False, "error": "Suggestion not found"}), 404
+
+
+@automations_bp.route("/api/v1/automations/suggestions/<suggestion_id>/yaml", methods=["GET"])
+@require_api_key
+def get_suggestion_yaml(suggestion_id: str):
+    """Get automation YAML for a suggestion."""
+    if not _engine:
+        return jsonify({"error": "Automation engine not initialized"}), 503
+
+    automation = _engine.get_suggestion_yaml(suggestion_id)
+    if automation:
+        return Response(
+            yaml.dump(automation, default_flow_style=False, allow_unicode=True, sort_keys=False),
+            mimetype="text/yaml",
+        )
+    return jsonify({"ok": False, "error": "Suggestion not found"}), 404
+
+
+@automations_bp.route("/api/v1/automations/generate", methods=["POST"])
+@require_api_key
+def generate_suggestions():
+    """Generate suggestions from current data.
+
+    Body: {"schedule": [...], "comfort": {...}, "presence": {...}}
+    """
+    if not _engine:
+        return jsonify({"error": "Automation engine not initialized"}), 503
+
+    body = request.get_json(silent=True) or {}
+    generated = []
+
+    # Schedule-based suggestions
+    for item in body.get("schedule", []):
+        s = _engine.suggest_from_schedule(
+            device_type=item.get("device_type", "washer"),
+            start_hour=item.get("start_hour", 10),
+            end_hour=item.get("end_hour", 12),
+            days=item.get("days", "weekday"),
+        )
+        generated.append(s.id)
+
+    # Solar-based suggestions
+    for item in body.get("solar", []):
+        s = _engine.suggest_from_solar(
+            device_type=item.get("device_type", "ev_charger"),
+            surplus_threshold_kwh=item.get("threshold_kwh", 5.0),
+        )
+        generated.append(s.id)
+
+    # Comfort-based suggestions
+    for item in body.get("comfort", []):
+        s = _engine.suggest_from_comfort(
+            factor=item.get("factor", "co2"),
+            threshold=item.get("threshold", 1000),
+            action_entity=item.get("entity", "switch.ventilation"),
+            action_service=item.get("service", "switch.turn_on"),
+        )
+        generated.append(s.id)
+
+    # Presence-based suggestions
+    if body.get("presence"):
+        p = body["presence"]
+        s = _engine.suggest_from_presence(
+            away_minutes=p.get("away_minutes", 30),
+            entities=p.get("entities"),
+        )
+        generated.append(s.id)
+
+    return jsonify({"ok": True, "generated": len(generated), "ids": generated}), 201

--- a/copilot_core/rootfs/usr/src/app/copilot_core/automations/suggestion_engine.py
+++ b/copilot_core/rootfs/usr/src/app/copilot_core/automations/suggestion_engine.py
@@ -1,0 +1,378 @@
+"""Automation Suggestion Engine — Generate HA automations from patterns (v5.9.0).
+
+Analyzes behavioral patterns from Habitus rules, energy schedules, and comfort
+data to suggest Home Assistant automations. Generates valid HA automation YAML.
+
+Supported suggestion types:
+- Time-based: "Every weekday at 07:00, turn on kitchen lights"
+- Energy-based: "When solar surplus > 5kWh, start dishwasher"
+- Comfort-based: "When CO2 > 1000ppm, turn on ventilation"
+- Presence-based: "When nobody home for 30 min, turn off lights"
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class AutomationSuggestion:
+    """A suggested HA automation."""
+
+    id: str
+    title: str
+    description: str
+    category: str  # time, energy, comfort, presence
+    confidence: float  # 0-1
+    estimated_savings_eur: float | None = None
+    automation_yaml: dict[str, Any] = field(default_factory=dict)
+    source_pattern: str | None = None  # Which pattern triggered this
+    accepted: bool = False
+    dismissed: bool = False
+
+
+class AutomationSuggestionEngine:
+    """Generate automation suggestions from PilotSuite data."""
+
+    def __init__(self):
+        self._suggestions: dict[str, AutomationSuggestion] = {}
+        self._counter = 0
+        logger.info("AutomationSuggestionEngine initialized")
+
+    def suggest_from_schedule(
+        self, device_type: str, start_hour: int, end_hour: int, days: str = "weekday"
+    ) -> AutomationSuggestion:
+        """Generate time-based automation from schedule pattern."""
+        self._counter += 1
+        sid = f"auto-sched-{self._counter:04d}"
+
+        trigger_time = f"{start_hour:02d}:00:00"
+        action_time = f"{end_hour:02d}:00:00"
+
+        weekdays = (
+            ["mon", "tue", "wed", "thu", "fri"]
+            if days == "weekday"
+            else ["mon", "tue", "wed", "thu", "fri", "sat", "sun"]
+        )
+
+        entity_map = {
+            "washer": "switch.washing_machine",
+            "dryer": "switch.dryer",
+            "dishwasher": "switch.dishwasher",
+            "ev_charger": "switch.ev_charger",
+        }
+        entity = entity_map.get(device_type, f"switch.{device_type}")
+
+        device_names = {
+            "washer": "Waschmaschine",
+            "dryer": "Trockner",
+            "dishwasher": "Geschirrspueler",
+            "ev_charger": "E-Auto Laden",
+        }
+        name = device_names.get(device_type, device_type.title())
+
+        automation = {
+            "alias": f"PilotSuite: {name} automatisch starten",
+            "description": f"Startet {name} zum optimalen Zeitpunkt ({start_hour}:00-{end_hour}:00)",
+            "trigger": [
+                {
+                    "platform": "time",
+                    "at": trigger_time,
+                }
+            ],
+            "condition": [
+                {
+                    "condition": "time",
+                    "weekday": weekdays,
+                }
+            ],
+            "action": [
+                {
+                    "service": "switch.turn_on",
+                    "target": {"entity_id": entity},
+                },
+                {
+                    "delay": {"hours": end_hour - start_hour, "minutes": 0},
+                },
+                {
+                    "service": "switch.turn_off",
+                    "target": {"entity_id": entity},
+                },
+            ],
+            "mode": "single",
+        }
+
+        suggestion = AutomationSuggestion(
+            id=sid,
+            title=f"{name} automatisch um {start_hour}:00 starten",
+            description=(
+                f"Basierend auf dem Energiezeitplan: {name} laeuft optimal "
+                f"zwischen {start_hour}:00 und {end_hour}:00 ({days})."
+            ),
+            category="time",
+            confidence=0.8,
+            estimated_savings_eur=0.15,
+            automation_yaml=automation,
+            source_pattern=f"schedule:{device_type}:{start_hour}-{end_hour}",
+        )
+
+        self._suggestions[sid] = suggestion
+        return suggestion
+
+    def suggest_from_solar(
+        self, device_type: str, surplus_threshold_kwh: float = 5.0
+    ) -> AutomationSuggestion:
+        """Generate energy-based automation from solar surplus pattern."""
+        self._counter += 1
+        sid = f"auto-solar-{self._counter:04d}"
+
+        entity_map = {
+            "washer": "switch.washing_machine",
+            "dryer": "switch.dryer",
+            "dishwasher": "switch.dishwasher",
+            "ev_charger": "switch.ev_charger",
+        }
+        entity = entity_map.get(device_type, f"switch.{device_type}")
+        device_names = {
+            "washer": "Waschmaschine",
+            "dryer": "Trockner",
+            "dishwasher": "Geschirrspueler",
+            "ev_charger": "E-Auto Laden",
+        }
+        name = device_names.get(device_type, device_type.title())
+
+        automation = {
+            "alias": f"PilotSuite: {name} bei Solarueberschuss",
+            "description": f"Startet {name} wenn Solarueberschuss > {surplus_threshold_kwh} kWh",
+            "trigger": [
+                {
+                    "platform": "numeric_state",
+                    "entity_id": "sensor.pilotsuite_energy_production",
+                    "above": surplus_threshold_kwh,
+                }
+            ],
+            "condition": [
+                {
+                    "condition": "state",
+                    "entity_id": entity,
+                    "state": "off",
+                }
+            ],
+            "action": [
+                {
+                    "service": "switch.turn_on",
+                    "target": {"entity_id": entity},
+                }
+            ],
+            "mode": "single",
+        }
+
+        suggestion = AutomationSuggestion(
+            id=sid,
+            title=f"{name} bei Solarueberschuss starten",
+            description=(
+                f"Wenn die Solarproduktion {surplus_threshold_kwh} kWh uebersteigt, "
+                f"wird {name} automatisch gestartet."
+            ),
+            category="energy",
+            confidence=0.75,
+            estimated_savings_eur=0.25,
+            automation_yaml=automation,
+            source_pattern=f"solar:{device_type}:>{surplus_threshold_kwh}kwh",
+        )
+
+        self._suggestions[sid] = suggestion
+        return suggestion
+
+    def suggest_from_comfort(
+        self,
+        factor: str,
+        threshold: float,
+        action_entity: str,
+        action_service: str = "switch.turn_on",
+    ) -> AutomationSuggestion:
+        """Generate comfort-based automation."""
+        self._counter += 1
+        sid = f"auto-comfort-{self._counter:04d}"
+
+        factor_config = {
+            "co2": {
+                "sensor": "sensor.co2",
+                "name": "CO2-Wert",
+                "unit": "ppm",
+                "action_name": "Lueftung einschalten",
+            },
+            "temperature_high": {
+                "sensor": "sensor.temperature",
+                "name": "Temperatur",
+                "unit": "C",
+                "action_name": "Klimaanlage einschalten",
+            },
+            "temperature_low": {
+                "sensor": "sensor.temperature",
+                "name": "Temperatur",
+                "unit": "C",
+                "action_name": "Heizung erhoehen",
+            },
+            "humidity_high": {
+                "sensor": "sensor.humidity",
+                "name": "Luftfeuchtigkeit",
+                "unit": "%",
+                "action_name": "Entfeuchter einschalten",
+            },
+        }
+
+        config = factor_config.get(factor, {
+            "sensor": f"sensor.{factor}",
+            "name": factor.title(),
+            "unit": "",
+            "action_name": f"{action_entity} schalten",
+        })
+
+        is_below = factor in ("temperature_low",)
+
+        trigger = {
+            "platform": "numeric_state",
+            "entity_id": config["sensor"],
+        }
+        if is_below:
+            trigger["below"] = threshold
+        else:
+            trigger["above"] = threshold
+
+        automation = {
+            "alias": f"PilotSuite: {config['action_name']}",
+            "description": (
+                f"Automatisch {config['action_name']} wenn "
+                f"{config['name']} {'unter' if is_below else 'ueber'} "
+                f"{threshold} {config['unit']}"
+            ),
+            "trigger": [trigger],
+            "action": [
+                {
+                    "service": action_service,
+                    "target": {"entity_id": action_entity},
+                }
+            ],
+            "mode": "single",
+        }
+
+        suggestion = AutomationSuggestion(
+            id=sid,
+            title=f"{config['action_name']} bei {config['name']} {'<' if is_below else '>'} {threshold}{config['unit']}",
+            description=automation["description"],
+            category="comfort",
+            confidence=0.7,
+            automation_yaml=automation,
+            source_pattern=f"comfort:{factor}:{'<' if is_below else '>'}{threshold}",
+        )
+
+        self._suggestions[sid] = suggestion
+        return suggestion
+
+    def suggest_from_presence(
+        self,
+        away_minutes: int = 30,
+        entities: list[str] | None = None,
+    ) -> AutomationSuggestion:
+        """Generate presence-based automation (away mode)."""
+        self._counter += 1
+        sid = f"auto-presence-{self._counter:04d}"
+
+        target_entities = entities or [
+            "light.living_room", "light.kitchen", "light.bedroom",
+        ]
+
+        automation = {
+            "alias": "PilotSuite: Alles aus bei Abwesenheit",
+            "description": (
+                f"Schaltet Lichter aus wenn niemand fuer {away_minutes} Min. zu Hause ist"
+            ),
+            "trigger": [
+                {
+                    "platform": "state",
+                    "entity_id": "group.all_persons",
+                    "to": "not_home",
+                    "for": {"minutes": away_minutes},
+                }
+            ],
+            "action": [
+                {
+                    "service": "light.turn_off",
+                    "target": {"entity_id": target_entities},
+                }
+            ],
+            "mode": "single",
+        }
+
+        suggestion = AutomationSuggestion(
+            id=sid,
+            title=f"Lichter aus nach {away_minutes} Min. Abwesenheit",
+            description=automation["description"],
+            category="presence",
+            confidence=0.85,
+            estimated_savings_eur=0.10,
+            automation_yaml=automation,
+            source_pattern=f"presence:away:{away_minutes}min",
+        )
+
+        self._suggestions[sid] = suggestion
+        return suggestion
+
+    def get_suggestions(
+        self, category: str | None = None, include_dismissed: bool = False,
+    ) -> list[dict[str, Any]]:
+        """Get all suggestions, optionally filtered."""
+        results = []
+        for s in self._suggestions.values():
+            if not include_dismissed and s.dismissed:
+                continue
+            if category and s.category != category:
+                continue
+            results.append(self._to_dict(s))
+
+        results.sort(key=lambda x: x["confidence"], reverse=True)
+        return results
+
+    def accept_suggestion(self, suggestion_id: str) -> dict[str, Any] | None:
+        """Mark a suggestion as accepted (user approved)."""
+        s = self._suggestions.get(suggestion_id)
+        if s:
+            s.accepted = True
+            return self._to_dict(s)
+        return None
+
+    def dismiss_suggestion(self, suggestion_id: str) -> dict[str, Any] | None:
+        """Mark a suggestion as dismissed (user rejected)."""
+        s = self._suggestions.get(suggestion_id)
+        if s:
+            s.dismissed = True
+            return self._to_dict(s)
+        return None
+
+    def get_suggestion_yaml(self, suggestion_id: str) -> dict[str, Any] | None:
+        """Get the raw automation YAML for a suggestion."""
+        s = self._suggestions.get(suggestion_id)
+        if s:
+            return s.automation_yaml
+        return None
+
+    @staticmethod
+    def _to_dict(s: AutomationSuggestion) -> dict[str, Any]:
+        return {
+            "id": s.id,
+            "title": s.title,
+            "description": s.description,
+            "category": s.category,
+            "confidence": s.confidence,
+            "estimated_savings_eur": s.estimated_savings_eur,
+            "automation_yaml": s.automation_yaml,
+            "source_pattern": s.source_pattern,
+            "accepted": s.accepted,
+            "dismissed": s.dismissed,
+        }

--- a/copilot_core/rootfs/usr/src/app/tests/test_automation_suggestions.py
+++ b/copilot_core/rootfs/usr/src/app/tests/test_automation_suggestions.py
@@ -1,0 +1,225 @@
+"""Tests for Automation Suggestion Engine (v5.9.0)."""
+
+import pytest
+from copilot_core.automations.suggestion_engine import (
+    AutomationSuggestion,
+    AutomationSuggestionEngine,
+)
+
+
+@pytest.fixture
+def engine():
+    return AutomationSuggestionEngine()
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Schedule-based Suggestions
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestScheduleSuggestions:
+    def test_generates_suggestion(self, engine):
+        s = engine.suggest_from_schedule("washer", 10, 12)
+        assert isinstance(s, AutomationSuggestion)
+        assert s.category == "time"
+
+    def test_has_automation_yaml(self, engine):
+        s = engine.suggest_from_schedule("washer", 10, 12)
+        auto = s.automation_yaml
+        assert "alias" in auto
+        assert "trigger" in auto
+        assert "action" in auto
+
+    def test_trigger_is_time(self, engine):
+        s = engine.suggest_from_schedule("washer", 10, 12)
+        trigger = s.automation_yaml["trigger"][0]
+        assert trigger["platform"] == "time"
+        assert trigger["at"] == "10:00:00"
+
+    def test_weekday_condition(self, engine):
+        s = engine.suggest_from_schedule("washer", 10, 12, days="weekday")
+        condition = s.automation_yaml["condition"][0]
+        assert "mon" in condition["weekday"]
+        assert "sat" not in condition["weekday"]
+
+    def test_daily_condition(self, engine):
+        s = engine.suggest_from_schedule("washer", 10, 12, days="daily")
+        condition = s.automation_yaml["condition"][0]
+        assert "sat" in condition["weekday"]
+        assert "sun" in condition["weekday"]
+
+    def test_action_turns_on_and_off(self, engine):
+        s = engine.suggest_from_schedule("washer", 10, 12)
+        actions = s.automation_yaml["action"]
+        assert actions[0]["service"] == "switch.turn_on"
+        assert actions[2]["service"] == "switch.turn_off"
+
+    def test_delay_matches_duration(self, engine):
+        s = engine.suggest_from_schedule("washer", 10, 14)
+        delay = s.automation_yaml["action"][1]["delay"]
+        assert delay["hours"] == 4
+
+    def test_known_device_entity(self, engine):
+        s = engine.suggest_from_schedule("ev_charger", 0, 4)
+        entity = s.automation_yaml["action"][0]["target"]["entity_id"]
+        assert entity == "switch.ev_charger"
+
+    def test_unknown_device_fallback(self, engine):
+        s = engine.suggest_from_schedule("pool_pump", 14, 16)
+        entity = s.automation_yaml["action"][0]["target"]["entity_id"]
+        assert entity == "switch.pool_pump"
+
+    def test_confidence_positive(self, engine):
+        s = engine.suggest_from_schedule("washer", 10, 12)
+        assert s.confidence > 0
+
+    def test_stored_in_engine(self, engine):
+        s = engine.suggest_from_schedule("washer", 10, 12)
+        items = engine.get_suggestions()
+        assert len(items) == 1
+        assert items[0]["id"] == s.id
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Solar-based Suggestions
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestSolarSuggestions:
+    def test_generates_suggestion(self, engine):
+        s = engine.suggest_from_solar("ev_charger", 5.0)
+        assert s.category == "energy"
+
+    def test_trigger_is_numeric_state(self, engine):
+        s = engine.suggest_from_solar("dishwasher", 3.0)
+        trigger = s.automation_yaml["trigger"][0]
+        assert trigger["platform"] == "numeric_state"
+        assert trigger["above"] == 3.0
+
+    def test_condition_checks_off(self, engine):
+        s = engine.suggest_from_solar("washer")
+        condition = s.automation_yaml["condition"][0]
+        assert condition["state"] == "off"
+
+    def test_savings_positive(self, engine):
+        s = engine.suggest_from_solar("ev_charger")
+        assert s.estimated_savings_eur > 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Comfort-based Suggestions
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestComfortSuggestions:
+    def test_co2_suggestion(self, engine):
+        s = engine.suggest_from_comfort("co2", 1000, "switch.ventilation")
+        assert s.category == "comfort"
+        trigger = s.automation_yaml["trigger"][0]
+        assert trigger["above"] == 1000
+
+    def test_temperature_low_uses_below(self, engine):
+        s = engine.suggest_from_comfort("temperature_low", 18, "switch.heater")
+        trigger = s.automation_yaml["trigger"][0]
+        assert trigger["below"] == 18
+
+    def test_custom_service(self, engine):
+        s = engine.suggest_from_comfort("humidity_high", 70, "switch.dehumidifier", "switch.turn_on")
+        action = s.automation_yaml["action"][0]
+        assert action["service"] == "switch.turn_on"
+
+    def test_unknown_factor(self, engine):
+        s = engine.suggest_from_comfort("noise", 80, "switch.noise_cancel")
+        assert s.automation_yaml["trigger"][0]["above"] == 80
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Presence-based Suggestions
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestPresenceSuggestions:
+    def test_generates_suggestion(self, engine):
+        s = engine.suggest_from_presence(away_minutes=30)
+        assert s.category == "presence"
+
+    def test_trigger_is_state(self, engine):
+        s = engine.suggest_from_presence()
+        trigger = s.automation_yaml["trigger"][0]
+        assert trigger["platform"] == "state"
+        assert trigger["to"] == "not_home"
+
+    def test_custom_away_minutes(self, engine):
+        s = engine.suggest_from_presence(away_minutes=60)
+        trigger = s.automation_yaml["trigger"][0]
+        assert trigger["for"]["minutes"] == 60
+
+    def test_custom_entities(self, engine):
+        entities = ["light.office", "light.garage"]
+        s = engine.suggest_from_presence(entities=entities)
+        target = s.automation_yaml["action"][0]["target"]["entity_id"]
+        assert target == entities
+
+    def test_high_confidence(self, engine):
+        s = engine.suggest_from_presence()
+        assert s.confidence >= 0.8
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Get / Accept / Dismiss
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestManagement:
+    def test_get_all_suggestions(self, engine):
+        engine.suggest_from_schedule("washer", 10, 12)
+        engine.suggest_from_solar("ev_charger")
+        engine.suggest_from_presence()
+        items = engine.get_suggestions()
+        assert len(items) == 3
+
+    def test_filter_by_category(self, engine):
+        engine.suggest_from_schedule("washer", 10, 12)
+        engine.suggest_from_solar("ev_charger")
+        items = engine.get_suggestions(category="energy")
+        assert len(items) == 1
+        assert items[0]["category"] == "energy"
+
+    def test_accept_suggestion(self, engine):
+        s = engine.suggest_from_schedule("washer", 10, 12)
+        result = engine.accept_suggestion(s.id)
+        assert result["accepted"] is True
+
+    def test_dismiss_suggestion(self, engine):
+        s = engine.suggest_from_schedule("washer", 10, 12)
+        engine.dismiss_suggestion(s.id)
+        items = engine.get_suggestions()
+        assert len(items) == 0  # Dismissed hidden by default
+
+    def test_include_dismissed(self, engine):
+        s = engine.suggest_from_schedule("washer", 10, 12)
+        engine.dismiss_suggestion(s.id)
+        items = engine.get_suggestions(include_dismissed=True)
+        assert len(items) == 1
+
+    def test_accept_nonexistent(self, engine):
+        result = engine.accept_suggestion("nonexistent")
+        assert result is None
+
+    def test_get_yaml(self, engine):
+        s = engine.suggest_from_schedule("washer", 10, 12)
+        yaml_data = engine.get_suggestion_yaml(s.id)
+        assert "alias" in yaml_data
+        assert "trigger" in yaml_data
+
+    def test_get_yaml_nonexistent(self, engine):
+        result = engine.get_suggestion_yaml("nope")
+        assert result is None
+
+    def test_sorted_by_confidence(self, engine):
+        engine.suggest_from_comfort("co2", 1000, "switch.vent")  # 0.7
+        engine.suggest_from_presence()  # 0.85
+        engine.suggest_from_schedule("washer", 10, 12)  # 0.8
+        items = engine.get_suggestions()
+        confidences = [i["confidence"] for i in items]
+        assert confidences == sorted(confidences, reverse=True)


### PR DESCRIPTION
## Summary
- New `automations/suggestion_engine.py` generating HA automation YAML
- 4 suggestion types: time, solar, comfort, presence
- Accept/dismiss workflow, confidence scoring, savings estimates
- 5 API endpoints + 30+ tests

## Test plan
- [ ] `pytest tests/test_automation_suggestions.py`

https://claude.ai/code/session_01JsNTv2Rn83psriC7Fap15Y