### PR TITLE
fix(v7.7.4): Ollama port 11435 + smart external detection

### DIFF
--- a/copilot_core/config.yaml
+++ b/copilot_core/config.yaml
@@ -1,5 +1,5 @@
 name: PilotSuite Core
-version: "7.7.3"
+version: "7.7.4"
 slug: copilot_core
 description: "PilotSuite Styx — AI Home Copilot with Brain Architecture, Neural Sensors, and local LLM conversation."
 url: https://github.com/GreenhillEfka/pilotsuite-styx-core
@@ -26,7 +26,7 @@ webui: "http://[HOST]:[PORT:8909]/"
 options:
   log_level: info
   auth_token: ""
-  conversation_ollama_url: "http://localhost:11434"
+  conversation_ollama_url: "http://localhost:11435"
   conversation_ollama_model: "qwen3:4b"
   conversation_assistant_name: Styx
   conversation_enabled: true


### PR DESCRIPTION
## Summary
- Internal Ollama now binds to port **11435** (avoids conflicts with host Ollama on 11434)
- Auto-detects external Ollama URL in add-on options → skips internal startup entirely
- Default `conversation_ollama_url` updated to `http://localhost:11435`

## Test plan
- [ ] Add-on starts with default config (internal Ollama on 11435)
- [ ] Add-on starts with external Ollama URL (internal Ollama skipped)
- [ ] Models pull correctly on first start

https://claude.ai/code/session_01JsNTv2Rn83psriC7Fap15Y