### PR TITLE
chore(v7.7.5): version bump

### DIFF
--- a/copilot_core/config.yaml
+++ b/copilot_core/config.yaml
@@ -1,5 +1,5 @@
 name: PilotSuite Core
-version: "7.7.4"
+version: "7.7.5"
 slug: copilot_core
 description: "PilotSuite Styx — AI Home Copilot with Brain Architecture, Neural Sensors, and local LLM conversation."
 url: https://github.com/GreenhillEfka/pilotsuite-styx-core


### PR DESCRIPTION
## Summary
- Version bump to 7.7.5 to align with HA integration release

https://claude.ai/code/session_01JsNTv2Rn83psriC7Fap15Y